### PR TITLE
Added openapi folder to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.8.1-slim
 WORKDIR /usr/src/app
+COPY openapi ./openapi
 COPY requirements.txt .
 COPY vAPI.py .
 COPY vAPI.db .


### PR DESCRIPTION
The docker application was failing so i added a line to fix the errors.

See error details:

```
Traceback (most recent call last):
  File "./vAPI.py", line 315, in <module>
    app.add_api('vAPI.yaml', arguments={'title': 'Vulnerable API'})
  File "/usr/local/lib/python3.8/site-packages/connexion/apps/flask_app.py", line 57, in add_api
    api = super(FlaskApp, self).add_api(specification, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/connexion/apps/abstract.py", line 141, in add_api
    api = self.api_cls(specification,
  File "/usr/local/lib/python3.8/site-packages/connexion/apis/abstract.py", line 75, in __init__
    self.specification = Specification.load(specification, arguments=arguments)
  File "/usr/local/lib/python3.8/site-packages/connexion/spec.py", line 150, in load
    return cls.from_file(spec, arguments=arguments)
  File "/usr/local/lib/python3.8/site-packages/connexion/spec.py", line 106, in from_file
    spec = cls._load_spec_from_file(arguments, specification_path)
  File "/usr/local/lib/python3.8/site-packages/connexion/spec.py", line 90, in _load_spec_from_file
    with specification.open(mode='rb') as openapi_yaml:
  File "/usr/local/lib/python3.8/pathlib.py", line 1215, in open
    return io.open(self, mode, buffering, encoding, errors, newline,
  File "/usr/local/lib/python3.8/pathlib.py", line 1071, in _opener
    return self._accessor.open(self, flags, mode)
FileNotFoundError: [Errno 2] No such file or directory: '/usr/src/app/openapi/vAPI.yaml'
```